### PR TITLE
Stop using runtimeType to check objec type

### DIFF
--- a/lib/src/Xml2JsonBadgerfish.dart
+++ b/lib/src/Xml2JsonBadgerfish.dart
@@ -50,20 +50,20 @@ class _Xml2JsonBadgerfish {
       String marker = '"\$"';
       String xmlnsPrefix = '"@xmlns"';
       
-      if (node.runtimeType.toString() == "XmlText") {
+      if (node is XmlText) {
         
         /* Text node processing */
         String sanitisedNodeData = _Xml2JsonUtils.escapeTextForJson(node.data);
         String nodeData = '"'+sanitisedNodeData+'"';
-        if (obj["$marker"].runtimeType.toString() == "List") {
+        if (obj["$marker"] is List) {
           obj["$marker"].add(nodeData);
-        } else if (obj["$marker"].runtimeType.toString() == "_LinkedHashMap") {
+        } else if (obj["$marker"] is Map) {
           obj["$marker"] = [obj["$marker"], nodeData];
         } else {
           obj["$marker"] = nodeData;
         }
       
-      } else if (node.runtimeType.toString() == "XmlElement") {
+      } else if (node is XmlElement) {
         
         /* Element node processing */ 
         var p = {};
@@ -97,9 +97,9 @@ class _Xml2JsonBadgerfish {
            }
          }
         
-         if (obj[nodeName].runtimeType.toString() == "List") {
+         if (obj[nodeName] is List) {
           obj[nodeName].add(p);
-         } else if (obj[nodeName].runtimeType.toString() == "_LinkedHashMap" ) {
+         } else if (obj[nodeName] is Map) {
           obj[nodeName] = [obj[nodeName], p];
          } else {
           obj[nodeName] = p;
@@ -108,7 +108,7 @@ class _Xml2JsonBadgerfish {
           process(node.children[j], p, {});
          }
          
-      } else if (node.runtimeType.toString() == "XmlDocument") {
+      } else if (node is XmlDocument) {
         
           /* Document node processing */
           for (var k = 0; k < node.children.length; k++) {

--- a/lib/src/Xml2JsonGData.dart
+++ b/lib/src/Xml2JsonGData.dart
@@ -29,20 +29,20 @@ class _Xml2JsonGData {
       String marker = '"\$t"';
       String xmlnsPrefix = '"xmlns"';
       
-      if (node.runtimeType.toString() == "XmlText") {
+      if (node is XmlText) {
         
         /* Text node processing */
         String sanitisedNodeData = _Xml2JsonUtils.escapeTextForJson(node.data);
-        String nodeData = '"'+sanitisedNodeData+'"';   
-        if (obj["$marker"].runtimeType.toString() == "List") {
+        String nodeData = '"'+sanitisedNodeData+'"';
+        if (obj["$marker"] is List) {
             obj["$marker"].add(nodeData);
-        } else if (obj["$marker"].runtimeType.toString() == "_LinkedHashMap") {
+        } else if (obj["$marker"] is Map) {
             obj["$marker"] = [obj["$marker"], nodeData];
         } else { 
           obj["$marker"] = nodeData;
         }
         
-      } else if ((node.runtimeType.toString() == "XmlElement")) {
+      } else if (node is XmlElement) {
         
         /* Element node processing */ 
         var p = {};
@@ -76,9 +76,9 @@ class _Xml2JsonGData {
            }
          }
          
-         if (obj[nodeName].runtimeType.toString() == "List") {
+         if (obj[nodeName].runtimeType is List) {
            obj[nodeName].add(p);
-         } else if (obj[nodeName].runtimeType.toString() == "_LinkedHashMap" ) {
+         } else if (obj[nodeName].runtimeType is Map) {
           obj[nodeName] = [obj[nodeName], p];
          } else {
           obj[nodeName] = p;
@@ -88,13 +88,13 @@ class _Xml2JsonGData {
           process(node.children[j], p, {});
          }
          
-      } else if (node.runtimeType.toString() == "XmlDocument") {
+      } else if (node is XmlDocument) {
         
           /* Document node processing */
           for (var k = 0; k < node.children.length; k++) {
             process(node.children[k], obj, {});
           }
-      }  else if (node.runtimeType.toString() == "XmlProcessing") {
+      }  else if (node is XmlProcessing) {
         
           /* Processing node, only text in this node */
           String processingString = node.data;

--- a/lib/src/Xml2JsonParker.dart
+++ b/lib/src/Xml2JsonParker.dart
@@ -39,18 +39,18 @@ class _Xml2JsonParker{
    */
   Map _transform(var node, var obj) {
     
-      if (node.runtimeType.toString() == "XmlElement") {
+      if (node is XmlElement) {
           
             var nodeName = "\"${node.name.qualified}\"";
-            if (obj[nodeName].runtimeType.toString() == "List") {
+            if (obj[nodeName] is List) {
               obj[nodeName].add({});
               obj = obj[nodeName].last;
-            } else if (obj[nodeName].runtimeType.toString() == "_LinkedHashMap" ) {
+            } else if (obj[nodeName] is Map) {
               obj[nodeName] = [obj[nodeName], {}];
               obj = obj[nodeName].last;
             } else { 
               if ( node.children.length >=1 ) {
-                if (node.children[0].runtimeType.toString() == "XmlText" ) {
+                if (node.children[0] is XmlText) {
                   String sanitisedNodeData = _Xml2JsonUtils.escapeTextForJson(node.children[0].data);
                   String nodeData = '"'+sanitisedNodeData+'"';
                   if ( nodeData.isEmpty) nodeData = null;
@@ -71,7 +71,7 @@ class _Xml2JsonParker{
           
         
       
-      } else if (node.runtimeType.toString() == "XmlDocument") {
+      } else if (node is XmlDocument) {
         
         for (var j = 0; j < node.children.length; j++) { 
           _transform(node.children[j], obj);


### PR DESCRIPTION
Since Dart SDK version 1.4.0-dev.5.1, List.runtimeType.toString() changed from "List" to "JSArray" in dart compiled JavaScript which caused an unexpected behavior. According to dart team, https://code.google.com/p/dart/issues/detail?id=18644, runtimeType is not reliable, we shouldn't rely on runtimeType to check object type.

Changed to use is instead.
