### PR TITLE
Move browser to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ description: An XML to JSON conversion package.
 homepage: https://github.com/shamblett/xml2json
 documentation: http://oscf.org.uk/dart/api/xml2json/xml2json/Xml2Json.html
 dependencies:
-  browser: any
   petitparser: '>=1.0.1'
 dev_dependencies:
+  browser: any
   meta: any
   unittest: any


### PR DESCRIPTION
Moved browser to dev_dependencies because it wasn't used in lib code.

The reason I am doing this is that it caused a compatibility issue in latest dart (Dart SDK version 1.5.0-dev.1.1). Although browser version was set to any in xml2json, pub complained its version didn't compatible with angular.

*\* Warning: Application may fail to run since packages did not get installed.Try running pub get again. **
Pub upgrade failed, [1] Resolving dependencies... (5.3s)
Incompatible version constraints on browser:
- angular 0.11.0 depends on version >=0.10.0 <0.11.0
- xml2json 2.0.2 depends on version >=0.9.1 <0.10.0
