### PR TITLE
Use secure links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ tree into the following XML JSON conventions :-
 2. Badgerfish
 3. Google Data(GData).
 
-The package uses the [xml](http://pub.dartlang.org/packages/xml) parser to peform the parsing of XML data into a parse tree.
+The package uses the [xml](https://pub.dev/packages/xml) parser to peform the parsing of XML data into a parse tree.
 
 Exact transforming rules can be found in the 'Transforming Details' document in the docs folder.
 


### PR DESCRIPTION
## Description

Use secure links in README to improve pub points.
Also use pub.dev instead of pub.dartlang.org links which is again redirected to pub.dev.

## Checklist

- [x] I am willing to follow-up on review comments in a timely manner.